### PR TITLE
Update rofi-randr

### DIFF
--- a/rofi-randr
+++ b/rofi-randr
@@ -22,6 +22,7 @@ function main() {
   xrandr_cmd='xrandr'
 
   while ! all_outputs_configured && (( $iteration <= $max_iteration )); do
+    mode=""
     if (( iteration++ )); then
       select_output 'Select next output:' 'unconfigured' | read output
       select_position "${output}" | read position


### PR DESCRIPTION
If you provide a mode, the monitor will be activated, even when defined as '--off'.
And as the 'mode' variable is kept between loop runs, it must explicitly be set to nothing.